### PR TITLE
visual from_file typo fix

### DIFF
--- a/src/visual/visual.rs
+++ b/src/visual/visual.rs
@@ -86,7 +86,7 @@ impl Visual {
     ///
     /// It needs notcurses to be compiled with multimedia capabilities.
     #[inline]
-    pub fn from_file(self, file: &str) -> Result<Visual> {
+    pub fn from_file(file: &str) -> Result<Visual> {
         Visual::builder().build_from_file(file)
     }
 


### PR DESCRIPTION
from_file(self,path: &str) -> from_file(path: &str)